### PR TITLE
Randomize bad cloud images

### DIFF
--- a/GameArea.js
+++ b/GameArea.js
@@ -9,7 +9,6 @@ import { Dimensions } from 'react-native';
 
 import Grass from './components/Grass';
 import Pot from './components/Pot';
-import BadCloud from './components/BadCloud';
 import Flower from './components/Flower';
 
 const max_height = Dimensions.get('screen').height;
@@ -18,7 +17,6 @@ const max_width = Dimensions.get('screen').width;
 export default class GameArea extends Component {
   constructor(props) {
     super(props);
-    this.badClouds = [];
     this.GameEngine = null;
     this.entities = this.setupWorld();
   }

--- a/assets/Images.js
+++ b/assets/Images.js
@@ -1,0 +1,5 @@
+export default Images = {
+  badCloud1: require('./bad_cloud1.png'),
+  badCloud2: require('./bad_cloud2.png'),
+  badCloud3: require('./bad_cloud3.png'),
+}

--- a/components/BadCloud.js
+++ b/components/BadCloud.js
@@ -23,6 +23,7 @@ export default class BadCloud extends Component {
         top: y,
         left: x
       }}
+      resizeMode="stretch"
       source={cloudImage} />
     ) 
   } 

--- a/components/BadCloud.js
+++ b/components/BadCloud.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Image } from 'react-native';
+import Images from '../assets/Images';
 
 export default class BadCloud extends Component {
   render() {
@@ -7,6 +8,11 @@ export default class BadCloud extends Component {
   const height = this.props.size[1]; 
   const x = this.props.body.position.x;
   const y = this.props.body.position.y;
+  // const cloudNumber = this.props.cloudNumber
+  // const cloudImage = '../assets/bad_cloud' + cloudNumber + '.png'
+
+  let cloudImage = Images['badCloud' + this.props.cloudNumber];
+
 
     return (
       <Image 
@@ -17,7 +23,7 @@ export default class BadCloud extends Component {
         top: y,
         left: x
       }}
-      source={require('../assets/bad_cloud1.png')} />
+      source={cloudImage} />
     ) 
   } 
 }

--- a/systems/BadCloudPhysics.js
+++ b/systems/BadCloudPhysics.js
@@ -7,17 +7,17 @@ const max_width = Dimensions.get('screen').width;
 
 let badClouds = 0;
 
-const randomizePos = (min, max) => {
+const randomizeNumber = (min, max) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
 const spawnBadClouds = (world, entities) => {
 
-  let badCloud = Matter.Bodies.rectangle(randomizePos(0, max_width), randomizePos(0, -500), 117, 60, {isStatic: true });
+  let badCloud = Matter.Bodies.rectangle(randomizeNumber(0, max_width), randomizeNumber(0, -500), 117, 60, {isStatic: true });
 
   Matter.World.add(world, [badCloud]);
 
-  let cloudNumber = randomizePos(1, 3)
+  let cloudNumber = randomizeNumber(1, 3)
 
   entities["badCloud" + (badClouds + 1)] = {
     body: badCloud,

--- a/systems/BadCloudPhysics.js
+++ b/systems/BadCloudPhysics.js
@@ -17,9 +17,12 @@ const spawnBadClouds = (world, entities) => {
 
   Matter.World.add(world, [badCloud]);
 
+  let cloudNumber = randomizePos(1, 3)
+
   entities["badCloud" + (badClouds + 1)] = {
     body: badCloud,
     size: [117, 60],
+    cloudNumber: cloudNumber,
     renderer: BadCloud
   }
 

--- a/systems/BadCloudPhysics.js
+++ b/systems/BadCloudPhysics.js
@@ -13,7 +13,7 @@ const randomizeNumber = (min, max) => {
 
 const spawnBadClouds = (world, entities) => {
 
-  let badCloud = Matter.Bodies.rectangle(randomizeNumber(0, max_width), randomizeNumber(0, -500), 117, 60, {isStatic: true });
+  let badCloud = Matter.Bodies.rectangle(randomizeNumber(0, max_width - 50), randomizeNumber(0, -max_height), 117, 60, {isStatic: true });
 
   Matter.World.add(world, [badCloud]);
 
@@ -38,6 +38,7 @@ const BadCloudPhysics = (entities, { touches, time }) => {
   let hadTouches = false;
   touches.filter(t => t.type === "press").forEach(t => {
     if (!hadTouches){
+      spawnBadClouds(world, entities);
       spawnBadClouds(world, entities);
       spawnBadClouds(world, entities);
       spawnBadClouds(world, entities);


### PR DESCRIPTION
Added an Images.js in assets to export the cloud images (was not able to get it to work otherwise). Importing the file in the BadCloud component and rendering picture 1, 2 or 3 depending on the props. The number is randomized in BadCloudPhysics and passed as prop.
Also made the span for spawning clouds higher above the screen and added one more cloud.