### PR TITLE
Change waterlevel depending on hits

### DIFF
--- a/GameArea.js
+++ b/GameArea.js
@@ -10,7 +10,7 @@ import { Dimensions } from 'react-native';
 import Grass from './components/Grass';
 import Pot from './components/Pot';
 import Flower from './components/Flower';
-import WaterMeter from './components/WaterMeter';
+// import WaterMeter from './components/WaterMeter';
 import Test from './components/Test';
 
 const max_height = Dimensions.get('screen').height;
@@ -22,7 +22,7 @@ export default class GameArea extends Component {
 
     this.state = {
       time: 0,
-      score: 100
+      waterLevel: 160
     };
 
     this.GameEngine = null;
@@ -38,7 +38,7 @@ export default class GameArea extends Component {
     let grass = Matter.Bodies.rectangle(0, max_height - 150, max_width, 150, { isStatic: true });
     let pot = Matter.Bodies.rectangle(max_width / 2 - 50, max_height - 140, 100, 80, { isStatic: true });
     let flower = Matter.Bodies.rectangle(max_width / 2 - 38 , max_height / 2, 76, 79, { isStatic: true });
-    let waterMeter = Matter.Bodies.rectangle(20, max_height - 300, 30, 170, { isStatic: true });
+    // let waterMeter = Matter.Bodies.rectangle(20, max_height - 300, 30, 170, { isStatic: true });
     //let badCloud1 = Matter.Bodies.rectangle(this.randomizeXpos(0, max_width), -30, 117, 60, {isStatic: true });
     // let badCloud2 = Matter.Bodies.rectangle(this.randomizeXpos(0, max_width), -30, 117, 60, {isStatic: true });
     let test = Matter.Bodies.rectangle(100, max_height - 800, 50, 50, { isSensor: true });
@@ -83,6 +83,9 @@ export default class GameArea extends Component {
       this.setState({
         time: total_seconds
       })
+      if (this.state.waterLevel === 0) {
+        this.gameEngine.dispatch({ type: "game_over"});
+      }
     });
 
     return {
@@ -92,7 +95,7 @@ export default class GameArea extends Component {
       // badCloud1: { body: badCloud1, size: [117, 60], renderer: BadCloud},
       // badCloud2: { body: badCloud2, size: [117, 60], renderer: BadCloud},
       flower: { body: flower, color: 'blue', size: [76, 79], renderer: Flower},
-      waterMeter: { body: waterMeter, color: 'blue', size: [30, 170], score: this.state.score, renderer: WaterMeter},
+      // waterMeter: { body: waterMeter, color: 'blue', size: [30, 170], renderer: WaterMeter},
       test: { body: test, color: 'red', size: [50, 50], renderer: Test},
       //test2: { body: test2, color: 'blue', size: [50, 50], renderer: Test}
     }
@@ -101,12 +104,14 @@ export default class GameArea extends Component {
   onEvent = (e) => {
     if (e.type === "score_down"){
       this.setState({
-          score: this.state.score - 10
+          waterLevel: this.state.waterLevel - 20
       });
     } if (e.type === "score_up") {
       this.setState({
-        score: this.state.score + 10
+        score: this.state.waterLevel + 20
       });
+    } if (e.type === "game_over") {
+      console.log("GAME OVER")
     }
   }
 
@@ -120,7 +125,7 @@ export default class GameArea extends Component {
           entities={this.entities}
           onEvent={this.onEvent}
         />
-        <Text style={styles.score}>{this.state.score}</Text>
+        <Text style={styles.score}>{this.state.waterLevel}</Text>
         <Text style={styles.scoreMeter}>{this.state.time}m</Text>
       </View>
     )

--- a/GameArea.js
+++ b/GameArea.js
@@ -12,6 +12,7 @@ import Pot from './components/Pot';
 import Flower from './components/Flower';
 // import WaterMeter from './components/WaterMeter';
 import Test from './components/Test';
+import WaterMeterBackground from './components/WaterMeterBackground'
 
 const max_height = Dimensions.get('screen').height;
 const max_width = Dimensions.get('screen').width;
@@ -43,6 +44,7 @@ export default class GameArea extends Component {
     // let badCloud2 = Matter.Bodies.rectangle(this.randomizeXpos(0, max_width), -30, 117, 60, {isStatic: true });
     let test = Matter.Bodies.rectangle(100, max_height - 800, 50, 50, { isSensor: true });
     //let test2 = Matter.Bodies.rectangle(200, max_height - 700, 50, 50, { isSensor: true });
+    let waterMeterBackground = Matter.Bodies.rectangle(20, max_height - 300, 30, 160, { isStatic: true });
     
 
     Matter.World.add(world, [grass, pot, flower, test]);
@@ -97,7 +99,8 @@ export default class GameArea extends Component {
       flower: { body: flower, color: 'blue', size: [76, 79], renderer: Flower},
       // waterMeter: { body: waterMeter, color: 'blue', size: [30, 170], renderer: WaterMeter},
       test: { body: test, color: 'red', size: [50, 50], renderer: Test},
-      //test2: { body: test2, color: 'blue', size: [50, 50], renderer: Test}
+      //test2: { body: test2, color: 'blue', size: [50, 50], renderer: Test},
+      waterMeterBackground: { body: waterMeterBackground, color: 'grey', size: [30, 160], renderer: WaterMeterBackground}
     }
   }
 

--- a/GameArea.js
+++ b/GameArea.js
@@ -92,7 +92,7 @@ export default class GameArea extends Component {
       // badCloud1: { body: badCloud1, size: [117, 60], renderer: BadCloud},
       // badCloud2: { body: badCloud2, size: [117, 60], renderer: BadCloud},
       flower: { body: flower, color: 'blue', size: [76, 79], renderer: Flower},
-      waterMeter: { body: waterMeter, color: 'blue', size: [30, 170], renderer: WaterMeter},
+      waterMeter: { body: waterMeter, color: 'blue', size: [30, 170], score: this.state.score, renderer: WaterMeter},
       test: { body: test, color: 'red', size: [50, 50], renderer: Test},
       //test2: { body: test2, color: 'blue', size: [50, 50], renderer: Test}
     }

--- a/components/WaterMeter.js
+++ b/components/WaterMeter.js
@@ -7,22 +7,35 @@ export default class WaterMeter extends Component {
   const height = this.props.size[1]; 
   const x = this.props.body.position.x;
   const y = this.props.body.position.y;
+  const score = this.props.score;
 
     return (
-      <View 
-      style={{
-        position: 'absolute',
-        width: width,
-        height: height,
-        top: y,
-        left: x,
-        backgroundColor: this.props.color,
-        opacity: 0.6,
-        borderRadius: 15,
-        borderWidth: 4,
-        borderColor: 'darkblue'
-      }}
-      />
+      <View>
+        <View style={{
+          position: 'absolute',
+          width: width,
+          height: height,
+          top: y,
+          left: x,
+          backgroundColor: this.props.color,
+          opacity: 0.6,
+          borderRadius: 15,
+          borderWidth: 4,
+          borderColor: 'darkblue'
+          }}
+        />
+      <View style={{
+          position: 'absolute',
+          width: width,
+          height: score,
+          top: y + height - score,
+          left: x,
+          borderRadius: 15,
+          backgroundColor: 'red',
+          opacity: 0.6,
+          }}
+        />
+      </View>
     ) 
   } 
 }

--- a/components/WaterMeter.js
+++ b/components/WaterMeter.js
@@ -7,7 +7,6 @@ export default class WaterMeter extends Component {
   const height = this.props.size[1]; 
   const x = this.props.body.position.x;
   const y = this.props.body.position.y;
-  const score = this.props.score;
 
     return (
       <View>
@@ -24,7 +23,7 @@ export default class WaterMeter extends Component {
           borderColor: 'darkblue'
           }}
         />
-      <View style={{
+      {/* <View style={{
           position: 'absolute',
           width: width,
           height: score,
@@ -34,7 +33,7 @@ export default class WaterMeter extends Component {
           backgroundColor: 'red',
           opacity: 0.6,
           }}
-        />
+        /> */}
       </View>
     ) 
   } 

--- a/components/WaterMeterBackground.js
+++ b/components/WaterMeterBackground.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
-export default class WaterMeter extends Component {
+export default class WaterMeterBackground extends Component {
   render() {
   const width = this.props.size[0];
   const height = this.props.size[1]; 

--- a/systems/FlowerPhysics.js
+++ b/systems/FlowerPhysics.js
@@ -7,14 +7,10 @@ const min_width = 0;
 
 const FlowerPhysics = (entities, { touches }) => {
   let flower = entities.flower.body;
-
-  
   // Function for the touch movement of the flower
   touches.filter(t => t.type === 'move').forEach(t => {
     const flowerDiameter = 76;
-
       Matter.Body.setPosition(flower, { x: t.event.locationX - 38, y: max_height / 2 });
-    
     if (flower.position.x > max_width - flowerDiameter) {
       Matter.Body.setPosition(flower, { x: max_width - flowerDiameter, y: max_height / 2});
     } if (flower.position.x < min_width) {

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -15,7 +15,7 @@ const updateWaterMeter = (world, entities) => {
 
   entities["waterMeter"] = {
     body: waterMeter, 
-    color: 'blue', 
+    color: '#1F63E0', 
     size: [30, waterLevel], 
     renderer: WaterMeter
   }

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -1,0 +1,42 @@
+import Matter from 'matter-js'
+import { Dimensions } from 'react-native';
+import WaterMeter from '../components/WaterMeter';
+
+const max_height = Dimensions.get('screen').height;
+const max_width = Dimensions.get('screen').width;
+let waterLevel = 160
+let newWaterMeterY = max_height - 300
+
+const updateWaterMeter = (world, entities) => {
+
+  let waterMeter = Matter.Bodies.rectangle(20, newWaterMeterY, 30, waterLevel, { isStatic: true });
+
+  Matter.World.add(world, [waterMeter]);
+
+  entities["waterMeter"] = {
+    body: waterMeter, 
+    color: 'blue', 
+    size: [30, waterLevel], 
+    renderer: WaterMeter
+  }
+}
+
+const WaterMeterPhysics = (entities, onEvent) => {
+  let world = entities.physics.world;
+  let engine = entities.physics.engine;
+  let total_time = parseInt(Math.floor(engine.timing.timestamp));
+  if (total_time < 2000) {
+    updateWaterMeter(world, entities)
+  }
+  if (onEvent.events.length) {
+    if (onEvent.events[0].type === 'score_down') {
+      waterLevel -= 20;
+      newWaterMeterY +=20
+      delete(entities["waterMeter"])
+      updateWaterMeter(world, entities)
+    }
+  }
+  return entities;
+}
+
+export default WaterMeterPhysics;

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -4,8 +4,8 @@ import WaterMeter from '../components/WaterMeter';
 
 const max_height = Dimensions.get('screen').height;
 const max_width = Dimensions.get('screen').width;
-let waterLevel = 160
-let newWaterMeterY = max_height - 300
+let waterLevel = 160;
+let newWaterMeterY = max_height - 300;
 
 const updateWaterMeter = (world, entities) => {
 

--- a/systems/index.js
+++ b/systems/index.js
@@ -2,4 +2,5 @@ import Physics from './physics'
 import BadCloudPhysics from './BadCloudPhysics';
 import FlowerPhysics from './FlowerPhysics';
 import GroundPhysics from './GroundPhysics';
-export default [Physics, BadCloudPhysics, FlowerPhysics, GroundPhysics];
+import WaterMeterPhysics from './WaterMeterPhysics'
+export default [Physics, BadCloudPhysics, FlowerPhysics, GroundPhysics, WaterMeterPhysics];


### PR DESCRIPTION
Rendering waterMeter inside WaterMeterPhysics in order to be able to update it. Checking the onEvent in WaterMeterPhysics to see if "score_down" is dispatched from GameArea. If so, the waterMeter is shortened with 20 points. 
Inside GameArea there's a variable to also keep track of the water level. If it's 0, "game_over" is dispatched.