### PR TITLE
Make water meter go up with collision

### DIFF
--- a/GameArea.js
+++ b/GameArea.js
@@ -107,12 +107,14 @@ export default class GameArea extends Component {
   onEvent = (e) => {
     if (e.type === "score_down"){
       this.setState({
-          waterLevel: this.state.waterLevel - 20
+        waterLevel: this.state.waterLevel - 20
       });
     } if (e.type === "score_up") {
-      this.setState({
-        score: this.state.waterLevel + 20
-      });
+      if (this.state.waterLevel < 160) {
+        this.setState({
+          waterLevel: this.state.waterLevel + 20
+        });
+      }
     } if (e.type === "game_over") {
       console.log("GAME OVER")
     }

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -31,16 +31,16 @@ const WaterMeterPhysics = (entities, onEvent) => {
   if (onEvent.events.length) {
     if (onEvent.events[0].type === 'score_down') {
       waterLevel -= 20;
-      newWaterMeterY +=20
-      delete(entities["waterMeter"])
-      updateWaterMeter(world, entities)
+      newWaterMeterY +=20;
+      delete(entities["waterMeter"]);
+      updateWaterMeter(world, entities);
     }
     if (onEvent.events[0].type === 'score_up') {
       if (waterLevel < 160) {
         waterLevel += 20;
-        newWaterMeterY -=20
-        delete(entities["waterMeter"])
-        updateWaterMeter(world, entities)
+        newWaterMeterY -=20;
+        delete(entities["waterMeter"]);
+        updateWaterMeter(world, entities);
       }
     }
   }

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -35,6 +35,14 @@ const WaterMeterPhysics = (entities, onEvent) => {
       delete(entities["waterMeter"])
       updateWaterMeter(world, entities)
     }
+    if (onEvent.events[0].type === 'score_up') {
+      if (waterLevel < 160) {
+        waterLevel += 20;
+        newWaterMeterY -=20
+        delete(entities["waterMeter"])
+        updateWaterMeter(world, entities)
+      }
+    }
   }
   return entities;
 }


### PR DESCRIPTION
Making the water meter go up in the WaterMeterPhysics if "score_up" is dispatched from GameArea and the water meter height is less than its maximum height (160). Also detracting from the water level in GameArea if the value is less than 160.