### PR TITLE
Ground falling by gravity

### DIFF
--- a/GameArea.js
+++ b/GameArea.js
@@ -38,11 +38,13 @@ export default class GameArea extends Component {
   setupWorld = () => {
     let engine = Matter.Engine.create({ enableSleeping: false });
     let world = engine.world;
-    engine.world.gravity.y = 0.05;
+    engine.world.gravity.y = 0.00;
+
+
 
     let flower = Matter.Bodies.rectangle(max_width / 2, max_height / 2, 60, 60, {isStatic: true});
-    let grass = Matter.Bodies.rectangle(max_width / 2, max_height - 50, max_width, 200, { isStatic: true });
-    let pot = Matter.Bodies.rectangle(max_width / 2, max_height - 120, 100, 80, { isStatic: true });
+    let grass = Matter.Bodies.rectangle(max_width / 2, max_height - 100, max_width, 200, {isSensor: true});
+    let pot = Matter.Bodies.rectangle(max_width / 2, max_height - 140, 100, 80, {isSensor: true});
     let waterMeterBackground = Matter.Bodies.rectangle(20, max_height - 300, 30, 160, { isStatic: true });
     
 
@@ -80,6 +82,9 @@ export default class GameArea extends Component {
       });
       if (this.state.waterLevel === 0) {
         this.gameEngine.dispatch({ type: "game_over"});
+      }
+      if (this.state.time === 2) {
+        engine.world.gravity.y = 0.05;
       }
     });
 

--- a/systems/GroundPhysics.js
+++ b/systems/GroundPhysics.js
@@ -2,17 +2,16 @@ import Matter from 'matter-js';
 import { Dimensions } from 'react-native';
 
 const max_height = Dimensions.get('screen').height;
+const max_width = Dimensions.get('screen').height;
 
 const GroundPhysics = (entities) => {
   let pot = entities.pot.body;
   let grass = entities.grass.body;
 
-  // Matter.Body.translate(pot, { x: 0, y: 1 });
-  // Matter.Body.translate(grass, { x: 0, y: 1 });
-  if (grass.position.y > max_height + 1000) {
-    grass.position.y = max_height + 1000;
-  } if (pot.position.y > max_height + 1000) {
-    pot.position.y = max_height + 1000;
+  if (grass.position.y > max_height + 100) {
+    Matter.Body.setStatic(grass, true)
+  } if (pot.position.y > max_height + 100) {
+    Matter.Body.setStatic(pot, true)
   }
 
   return entities;

--- a/systems/GroundPhysics.js
+++ b/systems/GroundPhysics.js
@@ -7,8 +7,8 @@ const GroundPhysics = (entities) => {
   let pot = entities.pot.body;
   let grass = entities.grass.body;
 
-  Matter.Body.translate(pot, { x: 0, y: 1 });
-  Matter.Body.translate(grass, { x: 0, y: 1 });
+  // Matter.Body.translate(pot, { x: 0, y: 1 });
+  // Matter.Body.translate(grass, { x: 0, y: 1 });
   if (grass.position.y > max_height + 1000) {
     grass.position.y = max_height + 1000;
   } if (pot.position.y > max_height + 1000) {


### PR DESCRIPTION
Removed isStatic on pot and ground in GameArea so that they fall by gravity and added isSensor instead (so that the pot can be rendered on top of the grass, otherwise the pot "collides" with grass and will be rendered over it). 
Added a timer on 2 sec inside beforeUpdate in GameArea before the gravity starts. 
I'm not able to remove the grass and pot when they leave the screen (don't think it's possible) so instead, I put isStatic on the bodies when they leave the screen.