### PR TITLE
Fix error at end of game

### DIFF
--- a/GameArea.js
+++ b/GameArea.js
@@ -4,7 +4,7 @@ import Systems from './systems'
 import { GameEngine } from 'react-native-game-engine';
 import Matter from 'matter-js';
 
-import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, Pressable } from 'react-native';
 import { Dimensions } from 'react-native';
 
 import Grass from './components/Grass';
@@ -150,12 +150,12 @@ export default class GameArea extends Component {
         />
         <Text style={styles.score}>{this.state.waterLevel}</Text>
         <Text style={styles.scoreMeter}>{this.state.time}m</Text>
-        {this.state.showGameOverScreen && !this.state.running && <TouchableOpacity onPress={this.resetGame} style={styles.fullScreenButton}>
+        {this.state.showGameOverScreen && !this.state.running && <Pressable onPress={this.resetGame} style={styles.fullScreenButton}>
           <GameOverScreen />
-        </TouchableOpacity>}
-        {this.state.showStartScreen && !this.state.running && <TouchableOpacity onPress={this.startGame} style={styles.fullScreenButton}>
+        </Pressable>}
+        {this.state.showStartScreen && !this.state.running && <Pressable onPress={this.startGame} style={styles.fullScreenButton}>
           <StartScreen />
-        </TouchableOpacity>}
+        </Pressable>}
       </View>
     )
   }

--- a/systems/WaterMeterPhysics.js
+++ b/systems/WaterMeterPhysics.js
@@ -3,9 +3,6 @@ const WaterMeterPhysics = (entities, onEvent) => {
     if (onEvent.events[0].type === 'score_down') {
       entities.waterMeter.waterLevel -= 32;
       entities.waterMeter.newWaterMeterY +=32;
-      if (entities.waterMeter.waterLevel === 0) {
-        delete(entities['waterMeter'])
-      }
     } 
     if (onEvent.events[0].type === 'score_up') {
       if (entities.waterMeter.waterLevel < 160) {


### PR DESCRIPTION
Not removing the waterMeter if the waterLevel is 0, but instead changed TouchableOpacity to Pressable so that the ended game underneath the Game Over screen never shows. 